### PR TITLE
removed bulk_insert test

### DIFF
--- a/t/sqlite/construct_fixture.t
+++ b/t/sqlite/construct_fixture.t
@@ -323,31 +323,6 @@ subtest 'multiple fixture from yaml' => sub {
     done_testing;
 };
 
-subtest 'fail bulk_insret' => sub {
-    my $dbh = $connector->dbh;
-    
-    my $database = construct_database(
-        dbh      => $dbh,
-        database => 't/sqlite/schema.yaml',
-        schema   => [qw/people/],
-    );
-
-    dies_ok(
-        sub {
-            construct_fixture(
-                dbh => $dbh,
-                opts => +{ bulk_insert => 1 },
-                fixture => $fixture->{people_001},
-            );
-        },
-        'bulk_insert not support',
-    );
-
-    $dbh->disconnect;
-    
-    done_testing;
-};
-
 done_testing;
 
 # Local Variables:


### PR DESCRIPTION
I tried to install Test::Fixture::DBI with cpanm, but test failed so that I did not able to install it.
I read cpanm's build log and realized that the test examines SQLite failed.
According to the log, the test tries to make sure that SQLite cannot use bulk insert.
However, SQLite is now compatible with bulk insert.
Here is SQLite's release log in 2012 http://www.sqlite.org/releaselog/3_7_11.html
Therefore, if a user have SQLite higher than 3.7.11, its test fails.
I think the subtest 'fail bulk_insert' test is now useless, so it should be removed.

Here is my build log.

```
cpanm (App::cpanminus) 1.7001 on perl 5.018002 built for darwin-2level
Work directory is /Users/ryo.a.kato/.cpanm/work/1398662511.70128
You have make /usr/bin/make
You have LWP 6.06
You have /usr/bin/tar: bsdtar 2.8.3 - libarchive 2.8.3
You have /usr/bin/unzip
Searching Test::Fixture::DBI on cpanmetadb ...
--> Working on Test::Fixture::DBI
Fetching http://www.cpan.org/authors/id/Z/ZI/ZIGOROU/Test-Fixture-DBI-0.07.tar.gz
-> OK
Unpacking Test-Fixture-DBI-0.07.tar.gz
Entering Test-Fixture-DBI-0.07
Checking configure dependencies from META.yml
Checking if you have ExtUtils::MakeMaker 6.42 ... Yes (6.66)
Configuring Test-Fixture-DBI-0.07
Running Makefile.PL
Cannot determine perl version info from lib/Test/Fixture/DBI.pm
Checking if your kit is complete...
Looks good
Writing Makefile for Test::Fixture::DBI
Writing MYMETA.yml and MYMETA.json
-> OK
Checking dependencies from MYMETA.json ...
Checking if you have parent 0 ... Yes (0.225)
Checking if you have UNIVERSAL::require 0 ... Yes (0.17)
Checking if you have Exporter 0 ... Yes (5.68)
Checking if you have DBI 0 ... Yes (1.631)
Checking if you have Getopt::Long 0 ... Yes (2.39)
Checking if you have Test::Exception 0 ... Yes (0.32)
Checking if you have SQL::Abstract::Plugin::InsertMulti 0 ... Yes (0.04)
Checking if you have Test::LoadAllModules 0 ... Yes (0.022)
Checking if you have Carp 0 ... Yes (1.29)
Checking if you have Scalar::Util 0 ... Yes (1.27)
Checking if you have Test::Requires 0 ... Yes (0.07)
Checking if you have File::Temp 0 ... Yes (0.23)
Checking if you have Test::More 0 ... Yes (1.001003)
Checking if you have ExtUtils::MakeMaker 6.42 ... Yes (6.66)
Checking if you have YAML::Syck 0 ... Yes (1.27)
Checking if you have Pod::Usage 0 ... Yes (1.61)
Checking if you have SQL::Abstract 0 ... Yes (1.77)
Building and testing Test-Fixture-DBI-0.07
cp lib/Test/Fixture/DBI/Util.pm blib/lib/Test/Fixture/DBI/Util.pm
cp lib/Test/Fixture/DBI.pm blib/lib/Test/Fixture/DBI.pm
cp lib/Test/Fixture/DBI/Util/SQLite.pm blib/lib/Test/Fixture/DBI/Util/SQLite.pm
cp lib/Test/Fixture/DBI/Util/mysql.pm blib/lib/Test/Fixture/DBI/Util/mysql.pm
cp ./script/make_fixture_yaml.pl blib/script/make_fixture_yaml.pl
/Users/ryo.a.kato/.plenv/versions/5.18.2/bin/perl5.18.2 "-Iinc" -MExtUtils::MY -e 'MY->fixin(shift)' -- blib/script/make_fixture_yaml.pl
cp ./script/make_database_yaml.pl blib/script/make_database_yaml.pl
/Users/ryo.a.kato/.plenv/versions/5.18.2/bin/perl5.18.2 "-Iinc" -MExtUtils::MY -e 'MY->fixin(shift)' -- blib/script/make_database_yaml.pl
Manifying blib/man1/make_database_yaml.pl.1
Manifying blib/man1/make_fixture_yaml.pl.1
Manifying blib/man3/Test::Fixture::DBI::Util.3
Manifying blib/man3/Test::Fixture::DBI::Util::mysql.3
Manifying blib/man3/Test::Fixture::DBI.3
Manifying blib/man3/Test::Fixture::DBI::Util::SQLite.3
PERL_DL_NONLAZY=1 /Users/ryo.a.kato/.plenv/versions/5.18.2/bin/perl5.18.2 "-MExtUtils::Command::MM" "-e" "test_harness(0, 'inc', 'blib/lib', 'blib/arch')" t/*.t t/mysql/*.t t/mysql/util/*.t t/sqlite/*.t t/sqlite/util/*.t
t/compile.t ......................... ok
t/mysql/construct_database.t ........ ok
t/mysql/construct_fixture.t ......... ok
t/mysql/construct_trigger.t ......... ok
t/mysql/util/make_database_yaml.t ... ok
t/sqlite/construct_database.t ....... ok

    #   Failed test 'bulk_insert not support'
    #   at t/sqlite/construct_fixture.t line 343.
    # Looks like you failed 1 test of 1.

#   Failed test 'fail bulk_insret'
#   at t/sqlite/construct_fixture.t line 349.
# Looks like you failed 1 test of 5.
t/sqlite/construct_fixture.t ........ 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/5 subtests 
t/sqlite/util/make_database_yaml.t .. ok

Test Summary Report
-------------------
t/sqlite/construct_fixture.t      (Wstat: 256 Tests: 5 Failed: 1)
  Failed test:  5
  Non-zero exit status: 1
Files=8, Tests=26, 45 wallclock secs ( 0.07 usr  0.02 sys +  3.38 cusr  2.72 csys =  6.19 CPU)
Result: FAIL
Failed 1/8 test programs. 1/26 subtests failed.
make: *** [test_dynamic] Error 255
-> FAIL Installing Test::Fixture::DBI failed. See /Users/ryo.a.kato/.cpanm/work/1398662511.70128/build.log for details. Retry with --force to force install it.

```
