### PR TITLE
fix warning when the value of the column was null

### DIFF
--- a/lib/Test/Fixture/DBI/Util.pm
+++ b/lib/Test/Fixture/DBI/Util.pm
@@ -38,7 +38,7 @@ sub make_fixture_yaml {
             @data,
             +{
                 name => ref $name_column
-                ? join( '_', map { $row->{$_} } @$name_column )
+                ? join( '_', map { defined $row->{$_} ? $row->{$_} : '' } @$name_column )
                 : $row->{$name_column},
                 schema => $schema,
                 data   => $row,


### PR DESCRIPTION
If the value of the column was null, warning occurs.
Was I mplemented measures.
